### PR TITLE
Add shots::[] macro

### DIFF
--- a/.github/workflows/asciidoc.yml
+++ b/.github/workflows/asciidoc.yml
@@ -21,7 +21,7 @@ jobs:
       run: |
         gem install bundler
         bundle install --jobs 4 --retry 3
-        bundle exec rake
+        shots=1 bundle exec rake
     - name: Create GH Pages
       uses: peaceiris/actions-gh-pages@v2
       env:

--- a/Rakefile
+++ b/Rakefile
@@ -27,15 +27,17 @@ task :html, [:lang] => [:generate_index_files] do |t, args|
   languages(args).each do |lang|
     puts "Generating #{lang}"
     Asciidoctor.convert_file "content/index.#{lang}.adoc",
-                             safe: :unsafe,
+                             safe: :safe,
                              to_file: "public/#{lang}/index.html",
-                             mkdirs: true
+                             mkdirs: true,
+                             attributes: { 'shots' => ENV['shots'] }
   end
 
   Asciidoctor.convert_file "content/index.adoc",
-                           safe: :unsafe,
+                           safe: :safe,
                            to_file: "public/index.html",
-                           mkdirs: true
+                           mkdirs: true,
+                           attributes: { 'shots' => ENV['shots'] }
 end
 
 task :list do
@@ -50,4 +52,23 @@ task :default => :html
 
 def languages(args)
   Array(args[:lang] || LANGUAGES)
+end
+
+require 'asciidoctor'
+require 'asciidoctor/extensions'
+
+class ShotInlineMacro < Asciidoctor::Extensions::InlineMacroProcessor
+  use_dsl
+
+  named :shot
+
+  def process parent, target, attrs
+    doc = parent.document
+    return unless doc.attributes['shots']
+    %(<span style="background-color: red; padding-left: 2; padding-right: 2;">shot!</span>)
+  end
+end
+
+Asciidoctor::Extensions.register do
+  inline_macro ShotInlineMacro if document.basebackend? 'html'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -65,7 +65,7 @@ class ShotInlineMacro < Asciidoctor::Extensions::InlineMacroProcessor
   def process parent, target, attrs
     doc = parent.document
     return unless doc.attributes['shots']
-    %(<span style="background-color: red; padding-left: 2; padding-right: 2;">shot!</span>)
+    %(<span style="color: white; font-weight: bold; background-color: red; padding-left: 2; padding-right: 2;">shot!</span>)
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -65,7 +65,7 @@ class ShotInlineMacro < Asciidoctor::Extensions::InlineMacroProcessor
   def process parent, target, attrs
     doc = parent.document
     return unless doc.attributes['shots']
-    %(<span style="color: white; font-weight: bold; background-color: red; padding-left: 2; padding-right: 2;">shot!</span>)
+    %(<span style="border-radius: 10px; padding: 2px 5px 2px 5px; color: white; font-weight: bold; background-color: red; font-family: sans-serif;">Shot</span>)
   end
 end
 

--- a/content/02/02.01/script.adoc
+++ b/content/02/02.01/script.adoc
@@ -27,7 +27,7 @@ Let’s start with a very basic example of Shouty’s behaviour. Something we mi
 
 Sean the shouter shouts "free bagels at Sean's" and Lucy the listener who happens to be stood across the street from his store, 15 metres away, hears him. She walks into Sean’s Coffee and takes advantage of the offer.
 
-::shot[]
+shot::[]
 We can translate this into a Gherkin scenario so that Cucumber can run it. Here's how that would look.
 
 [source,gherkin]
@@ -40,23 +40,23 @@ Scenario: Listener is within range
 
 You can see there are four special keywords being used here. `Scenario` just tells Cucumber we’re about to describe an example that it can execute. Then you see the lines beginning with Given, When and Then.
 
-::shot[]
+shot::[]
 `Given` is the context for the scenario. We’re putting the system into a specific state, ready for the scenario to unfold.
 
-::shot[]
+shot::[]
 `When` is an action. Something that happens to the system that will cause something else to happen: an outcome.
 
-::shot[]
+shot::[]
 `Then` is the outcome. It’s the behaviour we expect from the system when this action happens in this context.
 
 You’ll notice we’ve omitted from our outcome anything about Lucy walking into Sean’s store and making a purchase. Remember, Gherkin is supposed to describe the behaviour of the system, so it would be distracting to have it in our scenario.
 
 Each scenario has these three ingredients:
-::shot[]
+shot::[]
   a context,
-::shot[]
+shot::[]
   an action,
-::shot[]
+shot::[]
   and one or more outcomes.
 
 Together, they describe one single aspect of the behaviour of the system.

--- a/content/02/02.02/script.adoc
+++ b/content/02/02.02/script.adoc
@@ -1,9 +1,9 @@
 === Running the scenario with Cucumber
 ==== Installation
 
-// shot()
+shot::[]
 Before we get started make sure you have a modern version of Ruby installed,
-// shot()
+shot::[]
 and the Bundler gem. Open a command-prompt and type:
 
 [source,bash]
@@ -23,7 +23,7 @@ $ mkdir shouty
 // TODO: remove reference to editor
 Go use cd to go into that directory, and open it up in your editor:
 
-// shot()
+shot::[]
 First we’ll create a Gemfile that describes the Ruby gems we need for our project. We’ll add Cucumber and RSpec-Expectations.
 
 .Gemfile

--- a/content/02/02.02/script.js.adoc
+++ b/content/02/02.02/script.js.adoc
@@ -1,9 +1,9 @@
 === Running the scenario with Cucumber
 ==== Installation
 
-// shot()
+shot::[]
 Before we get started make sure you have a modern version of NodeJs,
-// shot()
+shot::[]
 and NPM installed:
 
 [source,bash]
@@ -24,9 +24,9 @@ $ mkdir shouty
 // TODO: remove reference to editor
 Go use cd to go into that directory, and open it up in your editor:
 
-// shot()
+shot::[]
 First we’ll create a `package.json` that describes the NPM packages we need for our project
-// shot()
+shot::[]
 and add the `cucumber` package to it.
 
 [source,bash]

--- a/content/02/02.02/script.ruby.adoc
+++ b/content/02/02.02/script.ruby.adoc
@@ -1,9 +1,9 @@
 === Running the scenario with Cucumber
 ==== Installation
 
-// shot()
+shot::[]
 Before we get started make sure you have a modern version of Ruby installed,
-// shot()
+shot::[]
 and the Bundler gem. Open a command-prompt and type:
 
 [source,bash]
@@ -23,7 +23,7 @@ $ mkdir shouty
 // TODO: remove reference to editor
 Go use cd to go into that directory, and open it up in your editor:
 
-// shot()
+shot::[]
 First we’ll create a Gemfile that describes the Ruby gems we need for our project. We’ll add Cucumber and RSpec-Expectations.
 
 .Gemfile

--- a/content/02/02.03/script.adoc
+++ b/content/02/02.03/script.adoc
@@ -14,13 +14,13 @@ Now we’re ready to create our first feature file. Call the file `hear_shout.fe
 $ touch features/hear_shout.feature
 ----
 
-// shot()
+shot::[]
 All feature files start with the keyword `Feature:`
-// shot()
+shot::[]
 followed by a name.
 It’s a good convention to give it a name that matches the file name.
 
-// shot()
+shot::[]
 Let’s write out our first scenario.
 
 .hear_shout.feature
@@ -35,7 +35,7 @@ Feature: Hear shout
 
 ===== Run Feature
 
-// shot()
+shot::[]
 Switch back to the command-prompt and run `cucumber`. You’ll see Cucumber has found our feature file and read it back to us. We can see a summary of the results at the bottom: one scenario, three steps - all undefined.
 
 // TODO: show output
@@ -68,20 +68,20 @@ Then("Lucy hears Sean’s message") do
 end
 ----
 
-// shot()
+shot::[]
 `Undefined` means Cucumber doesn’t know what to do for any of the three steps we wrote in our Gherkin scenario. It needs us to provide some step definitions.
 
-// shot()
+shot::[]
 Step definitions translate from the plain language you use in Gherkin into Ruby code.
 
-// shot()
+shot::[]
 When Cucumber runs a step, it looks for a step definition that matches the text in the step. If it finds one, then it executes the code in the step definition.
 
 If it doesn’t find one… well, you’ve just seen what happens. Cucumber helpfully prints out some code snippets that we can use as a basis for new step definitions.
-// shot()
+shot::[]
 Let’s copy those.
 
-// shot()
+shot::[]
 We’ll paste them into a Ruby file under a new directory called `step_definitions` underneath the `features` directory. I’ll just call it `steps.rb`.
 
 .steps.rb
@@ -100,12 +100,12 @@ Then("Lucy hears Sean’s message") do
 end
 ----
 
-// shot()
+shot::[]
 Now run Cucumber again.
 
-// shot()
+shot::[]
 This time the output is a little different. We now have a pending step and two skipped ones. This means Cucumber found all our step definitions, and executed the first one.
-// shot()
+shot::[]
 But that first step definition throws a `PendingException`, which causes Cucumber to stop, skip the rest of the steps, and mark the scenario as pending. 
 
 [source,bash]
@@ -132,10 +132,10 @@ It’s time to start work on our solution. At this point we need to do a little 
 
 Cucumber is telling us to write the code we wish we had. Let’s do it!
 
-// shot()
+shot::[]
 We’ll start by renaming the `int` parameter to something that better reflects its meaning. We’ll call it `distance`.
 
-// shot()
+shot::[]
 And we can print it to the terminal to see the captured result
 
 To keep things simple we’re going to assume all people are situated on a line - in a one-dimensional coordinate system. We can always introduce proper geo locations later. We’ll place sean in the centre and lucy 15 metres away from sean.
@@ -156,7 +156,7 @@ Then("Lucy hears Sean’s message") do
 end
 ----
 
-// shot()
+shot::[]
 If we run `cucumber` again on our terminal, we can see the number 15 pop up in the output
 
 [source,bash]

--- a/content/02/02.04/script.adoc
+++ b/content/02/02.04/script.adoc
@@ -1,6 +1,6 @@
 === Implement domain model
 
-// shot()
+shot::[]
 Once we have the boilerplate in place, we can start working on the actual code for our scenario.
 
 .steps.rb
@@ -20,10 +20,10 @@ Then("Lucy hears Sean’s message") do
 end
 ----
 
-// shot()
+shot::[]
 To implement the first step, we need to create a couple of person objects, with the specified distance between them. We could write it like this:
 
-// shot()
+shot::[]
 We should also remove the `pending` status, since we are now defining our step.
 
 [source,ruby]
@@ -68,9 +68,9 @@ cucumber features/hear_shout.feature:2 # Scenario: Listener is within range
 0m0.004s
 ----
 
-// shot()
+shot::[]
 Let’s give our solution a home by creating a `lib` directory.
-// shot()
+shot::[]
 We’ll put our Shouty application in a Ruby file called `shouty.rb` in that directory.
 
 [source,bash]
@@ -79,7 +79,7 @@ $ mkdir lib
 $ touch lib/shouty.rb
 ----
 
-// shot()
+shot::[]
 Create a Shouty module, then an empty Person class inside it.
 
 .lib/shouty.rb
@@ -92,7 +92,7 @@ module Shouty
 end
 ----
 
-// shot()
+shot::[]
 For now, we’ll just require the shouty application from our steps.rb file. In a later lesson we’ll talk more about how to organise this code a bit better.
 
 [source,ruby]
@@ -146,7 +146,7 @@ cucumber features/hear_shout.feature:2 # Scenario: Listener is within range
 0m0.004s
 ----
 
-// shot()
+shot::[]
 We'll add the definition without implementing it yet.
 
 [source,ruby]
@@ -160,7 +160,7 @@ module Shouty
 end
 ----
 
-// shot()
+shot::[]
 When we run the scenario again, the first step is green!
 
 [source,bash]

--- a/content/02/02.05/script.adoc
+++ b/content/02/02.05/script.adoc
@@ -9,13 +9,13 @@ We’ll follow the same flow to make the remaining two steps pass:
 
 In the second step definition, we want to tell Sean to shout something.
 
-// shot()
+shot::[]
 In order to send instructions to Sean, we need to store him in an instance variable, which we already have, so that he’ll be accessible from all of our step definitions.
 
-// shot()
+shot::[]
 On the `When` step, we can capture Sean's message using the `{string}` pattern like this:
 
-// shot()
+shot::[]
 And now we can now tell him to _shout_ the message:
 
 [source,ruby]
@@ -38,7 +38,7 @@ Then("Lucy hears Sean’s message") do
 end
 ----
 
-// shot()
+shot::[]
 Our Person class needs a shout method. 
 
 [source,bash]
@@ -62,7 +62,7 @@ cucumber features/hear_shout.feature:2 # Scenario: Listener is within range
 0m0.003s
 ----
 
-// shot()
+shot::[]
 Let’s not worry about the implementation yet. The most important thing right now is to discover the shape of our domain model.
 
 .shouty.rb
@@ -83,7 +83,7 @@ end
 
 ==== Get heard messages
 
-// shot()
+shot::[]
 The last step definition is where we implement a check, or assertion. We’ll verify that what Lucy has heard is exactly the same as what Sean shouted.
 
 Once again we’re are going to write the code we wish we had.
@@ -158,7 +158,7 @@ This is great! Whenever we do BDD, getting to our first failing test is a milest
 
 Now all we have to do is write the code to make it pass - that’s the easy bit!
 
-// shot()
+shot::[]
 In this case, we’re going to cheat. We have a one-line fix that will make this scenario pass, but it’s not a particularly future-proof implementation. Can you guess what it is?
 
 [source,ruby]
@@ -182,7 +182,7 @@ end
 
 I told you it wasn’t very future proof!
 
-// shot()
+shot::[]
 [source,bash]
 ----
 bundle exec cucumber


### PR DESCRIPTION
If you set `ENV['shots']` as you run `rake` you'll see the shots highlighted in the HTML output. Leave it off and they're hidden.

This needs rebasing onto master but my Ruby install seems to be too broken to install `awesome_print` and I need time to fix it.